### PR TITLE
Declare controller as a const

### DIFF
--- a/app/assets/javascripts/administrate-field-lazy_belongs_to/components/lazy_belongs_to.js
+++ b/app/assets/javascripts/administrate-field-lazy_belongs_to/components/lazy_belongs_to.js
@@ -27,7 +27,7 @@ function bindLazyBelongsTos() {
         clearTimeout(lastDebounce)
       }
 
-      controller = new AbortController()
+      const controller = new AbortController()
       const { signal } = controller
 
       lastDebounce = setTimeout(() => {

--- a/app/assets/javascripts/administrate-field-lazy_belongs_to/components/lazy_belongs_to.js
+++ b/app/assets/javascripts/administrate-field-lazy_belongs_to/components/lazy_belongs_to.js
@@ -21,13 +21,15 @@ function bindLazyBelongsTos() {
       if (controller) {
         // abort the previous request
         controller.abort()
+        controller = new AbortController()
+      } else {
+        controller = new AbortController()
       }
 
       if (lastDebounce) {
         clearTimeout(lastDebounce)
       }
 
-      const controller = new AbortController()
       const { signal } = controller
 
       lastDebounce = setTimeout(() => {


### PR DESCRIPTION
Asset precompilation kept failing for me in a project until I updated `controller` to be declared as a `const`